### PR TITLE
Fix for 3.2.0 - fail to build (No rule to make target 'devnet'.  Stop.)

### DIFF
--- a/src/aur.mjs
+++ b/src/aur.mjs
@@ -46,7 +46,7 @@ build() {
 
     export CGO_LDFLAGS="$LDFLAGS"
     export GIT_TAG="v${env("pkgver")}"
-    make erigon devnet downloader integration rpcdaemon sentry txpool sentinel caplin
+    make erigon downloader integration rpcdaemon sentry txpool sentinel caplin
 }
 
 package() {


### PR DESCRIPTION
Fixes https://github.com/erigontech/erigon-pkg/issues/2